### PR TITLE
make leading sign in error query response optional

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -38,7 +38,7 @@ func (e *CommandError) Error() string {
 }
 
 // match both with and without quotes around error message
-var cmdErrRegexp = regexp.MustCompile(`([+-]\d+),.?(.*?)(\"|$)`)
+var cmdErrRegexp = regexp.MustCompile(`([+-]?\d+),.?(.*?)(\"|$)`)
 
 func confirmError(cmd, errRes string) error {
 	re := cmdErrRegexp.Copy()

--- a/errors_test.go
+++ b/errors_test.go
@@ -46,6 +46,13 @@ func TestConfirmError(t *testing.T) {
 			},
 			want: nil,
 		},
+		"NoErrorWithoutSign": {
+			in: map[string]string{
+				"cmd":    "*CLS",
+				"errRes": "0,\"No error\"",
+			},
+			want: nil,
+		},
 		"NoErrorWithoutQuotes": {
 			in: map[string]string{
 				"cmd":    "foo",


### PR DESCRIPTION
The one SCPI device we have responds with `0,"No error"` to `SYST:ERR?`. This lead to an error `invalid format: 0,"No error"` despite everything was fine.
This PR makes the leading sign in the Regex optional.